### PR TITLE
geom_alt props

### DIFF
--- a/data/421/167/693/421167693.geojson
+++ b/data/421/167/693/421167693.geojson
@@ -193,6 +193,9 @@
     },
     "wof:country":"GN",
     "wof:created":1459008740,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"95720da86ee3488d1baceb998ce50cec",
     "wof:hierarchy":[
         {
@@ -203,7 +206,7 @@
         }
     ],
     "wof:id":421167693,
-    "wof:lastmodified":1566639714,
+    "wof:lastmodified":1582358465,
     "wof:name":"Dalaba",
     "wof:parent_id":85671385,
     "wof:placetype":"county",

--- a/data/421/175/263/421175263.geojson
+++ b/data/421/175/263/421175263.geojson
@@ -285,6 +285,9 @@
     },
     "wof:country":"GN",
     "wof:created":1459009061,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"8a205dd4687902ebd85d80a9ecdeb066",
     "wof:hierarchy":[
         {
@@ -295,7 +298,7 @@
         }
     ],
     "wof:id":421175263,
-    "wof:lastmodified":1566639717,
+    "wof:lastmodified":1582358467,
     "wof:name":"Forecariah",
     "wof:parent_id":85671403,
     "wof:placetype":"county",

--- a/data/421/180/037/421180037.geojson
+++ b/data/421/180/037/421180037.geojson
@@ -216,6 +216,9 @@
     },
     "wof:country":"GN",
     "wof:created":1459009242,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"dd8cac39c563724d424eb7f38ef45632",
     "wof:hierarchy":[
         {
@@ -226,7 +229,7 @@
         }
     ],
     "wof:id":421180037,
-    "wof:lastmodified":1566639716,
+    "wof:lastmodified":1582358467,
     "wof:name":"Telimele",
     "wof:parent_id":85671503,
     "wof:placetype":"county",

--- a/data/421/182/003/421182003.geojson
+++ b/data/421/182/003/421182003.geojson
@@ -175,6 +175,9 @@
     },
     "wof:country":"GN",
     "wof:created":1459009315,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"691fad999f6e20ccf744237b691c27ad",
     "wof:hierarchy":[
         {
@@ -185,7 +188,7 @@
         }
     ],
     "wof:id":421182003,
-    "wof:lastmodified":1566639721,
+    "wof:lastmodified":1582358468,
     "wof:name":"Lola",
     "wof:parent_id":85671461,
     "wof:placetype":"county",

--- a/data/421/182/471/421182471.geojson
+++ b/data/421/182/471/421182471.geojson
@@ -301,6 +301,9 @@
     },
     "wof:country":"GN",
     "wof:created":1459009331,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"6fac6ac4c6793693ed7c820328c27886",
     "wof:hierarchy":[
         {
@@ -311,7 +314,7 @@
         }
     ],
     "wof:id":421182471,
-    "wof:lastmodified":1566639721,
+    "wof:lastmodified":1582358468,
     "wof:name":"Pita",
     "wof:parent_id":85671485,
     "wof:placetype":"county",

--- a/data/421/183/313/421183313.geojson
+++ b/data/421/183/313/421183313.geojson
@@ -172,6 +172,9 @@
     },
     "wof:country":"GN",
     "wof:created":1459009365,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"4f67ca2fcde8ef59586d8aeb4b646022",
     "wof:hierarchy":[
         {
@@ -182,7 +185,7 @@
         }
     ],
     "wof:id":421183313,
-    "wof:lastmodified":1566639721,
+    "wof:lastmodified":1582358468,
     "wof:name":"Mandiana",
     "wof:parent_id":85671479,
     "wof:placetype":"county",

--- a/data/421/184/459/421184459.geojson
+++ b/data/421/184/459/421184459.geojson
@@ -184,6 +184,9 @@
     },
     "wof:country":"GN",
     "wof:created":1459009411,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"a53db20b48b71b24b5d4a291139516cf",
     "wof:hierarchy":[
         {
@@ -194,7 +197,7 @@
         }
     ],
     "wof:id":421184459,
-    "wof:lastmodified":1566639720,
+    "wof:lastmodified":1582358468,
     "wof:name":"Kerouane",
     "wof:parent_id":85671425,
     "wof:placetype":"county",

--- a/data/421/184/611/421184611.geojson
+++ b/data/421/184/611/421184611.geojson
@@ -83,6 +83,9 @@
     },
     "wof:country":"GN",
     "wof:created":1459009416,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"23405ba068ec537aedb6db7f89839e43",
     "wof:hierarchy":[
         {
@@ -94,7 +97,7 @@
         }
     ],
     "wof:id":421184611,
-    "wof:lastmodified":1566639720,
+    "wof:lastmodified":1582358468,
     "wof:name":"Yalenzou",
     "wof:parent_id":890455259,
     "wof:placetype":"localadmin",

--- a/data/421/184/941/421184941.geojson
+++ b/data/421/184/941/421184941.geojson
@@ -187,6 +187,9 @@
     },
     "wof:country":"GN",
     "wof:created":1459009427,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"5495b44f011b5005f39ca311e6cee9c2",
     "wof:hierarchy":[
         {
@@ -197,7 +200,7 @@
         }
     ],
     "wof:id":421184941,
-    "wof:lastmodified":1566639720,
+    "wof:lastmodified":1582358468,
     "wof:name":"Labe",
     "wof:parent_id":85671451,
     "wof:placetype":"county",

--- a/data/421/185/157/421185157.geojson
+++ b/data/421/185/157/421185157.geojson
@@ -193,6 +193,9 @@
     },
     "wof:country":"GN",
     "wof:created":1459009434,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"ad7b504b6a91b0519728293fea1d8ea6",
     "wof:hierarchy":[
         {
@@ -203,7 +206,7 @@
         }
     ],
     "wof:id":421185157,
-    "wof:lastmodified":1566639721,
+    "wof:lastmodified":1582358468,
     "wof:name":"Fria",
     "wof:parent_id":85671409,
     "wof:placetype":"county",

--- a/data/421/188/473/421188473.geojson
+++ b/data/421/188/473/421188473.geojson
@@ -121,6 +121,9 @@
     },
     "wof:country":"GN",
     "wof:created":1459009559,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"794c2800e141fa48928e7ebfdf7471d7",
     "wof:hierarchy":[
         {
@@ -131,7 +134,7 @@
         }
     ],
     "wof:id":421188473,
-    "wof:lastmodified":1566639717,
+    "wof:lastmodified":1582358467,
     "wof:name":"Faranah",
     "wof:parent_id":85671399,
     "wof:placetype":"county",

--- a/data/421/188/475/421188475.geojson
+++ b/data/421/188/475/421188475.geojson
@@ -124,6 +124,9 @@
     },
     "wof:country":"GN",
     "wof:created":1459009559,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"c269e898212f59724e29d2767999ef2f",
     "wof:hierarchy":[
         {
@@ -134,7 +137,7 @@
         }
     ],
     "wof:id":421188475,
-    "wof:lastmodified":1566639716,
+    "wof:lastmodified":1582358467,
     "wof:name":"Mamou",
     "wof:parent_id":85671473,
     "wof:placetype":"county",

--- a/data/421/188/933/421188933.geojson
+++ b/data/421/188/933/421188933.geojson
@@ -74,6 +74,9 @@
     },
     "wof:country":"GN",
     "wof:created":1459009588,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"9ffc490dc9aac7b0e80f084f5d595a94",
     "wof:hierarchy":[
         {
@@ -85,7 +88,7 @@
         }
     ],
     "wof:id":421188933,
-    "wof:lastmodified":1566639716,
+    "wof:lastmodified":1582358467,
     "wof:name":"Konkour\u00e9",
     "wof:parent_id":421188475,
     "wof:placetype":"localadmin",

--- a/data/421/189/675/421189675.geojson
+++ b/data/421/189/675/421189675.geojson
@@ -459,6 +459,9 @@
     },
     "wof:country":"GN",
     "wof:created":1459009633,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"8c3dce34051d2f5f7379b9427c797b75",
     "wof:hierarchy":[
         {
@@ -470,7 +473,7 @@
         }
     ],
     "wof:id":421189675,
-    "wof:lastmodified":1566639716,
+    "wof:lastmodified":1582358467,
     "wof:name":"Conakry",
     "wof:parent_id":421191023,
     "wof:placetype":"locality",

--- a/data/421/191/023/421191023.geojson
+++ b/data/421/191/023/421191023.geojson
@@ -424,6 +424,9 @@
     },
     "wof:country":"GN",
     "wof:created":1459009677,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"8c3dce34051d2f5f7379b9427c797b75",
     "wof:hierarchy":[
         {
@@ -434,7 +437,7 @@
         }
     ],
     "wof:id":421191023,
-    "wof:lastmodified":1566639719,
+    "wof:lastmodified":1582358467,
     "wof:name":"Conakry",
     "wof:parent_id":85671395,
     "wof:placetype":"county",

--- a/data/421/191/507/421191507.geojson
+++ b/data/421/191/507/421191507.geojson
@@ -61,6 +61,9 @@
     },
     "wof:country":"GN",
     "wof:created":1459009695,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"c5d1992498373034cb1d1544d05825f2",
     "wof:hierarchy":[
         {
@@ -72,7 +75,7 @@
         }
     ],
     "wof:id":421191507,
-    "wof:lastmodified":1566639719,
+    "wof:lastmodified":1582358467,
     "wof:name":"Sougu\u00e9ta",
     "wof:parent_id":890455267,
     "wof:placetype":"localadmin",

--- a/data/421/191/509/421191509.geojson
+++ b/data/421/191/509/421191509.geojson
@@ -52,6 +52,9 @@
     },
     "wof:country":"GN",
     "wof:created":1459009695,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"b0c5cd88b508b7cab3327292ac084dab",
     "wof:hierarchy":[
         {
@@ -63,7 +66,7 @@
         }
     ],
     "wof:id":421191509,
-    "wof:lastmodified":1566639719,
+    "wof:lastmodified":1582358467,
     "wof:name":"Kindia-Centre",
     "wof:parent_id":890455267,
     "wof:placetype":"localadmin",

--- a/data/421/191/557/421191557.geojson
+++ b/data/421/191/557/421191557.geojson
@@ -178,6 +178,9 @@
     },
     "wof:country":"GN",
     "wof:created":1459009697,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"56e446fd6366f01019fff6388a1b6e8d",
     "wof:hierarchy":[
         {
@@ -188,7 +191,7 @@
         }
     ],
     "wof:id":421191557,
-    "wof:lastmodified":1566639718,
+    "wof:lastmodified":1582358467,
     "wof:name":"Gaoual",
     "wof:parent_id":85671413,
     "wof:placetype":"county",

--- a/data/421/191/559/421191559.geojson
+++ b/data/421/191/559/421191559.geojson
@@ -181,6 +181,9 @@
     },
     "wof:country":"GN",
     "wof:created":1459009697,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"214b228eda81b117435c12dee393d940",
     "wof:hierarchy":[
         {
@@ -191,7 +194,7 @@
         }
     ],
     "wof:id":421191559,
-    "wof:lastmodified":1566639718,
+    "wof:lastmodified":1582358467,
     "wof:name":"Gueckedou",
     "wof:parent_id":85671417,
     "wof:placetype":"county",

--- a/data/421/198/015/421198015.geojson
+++ b/data/421/198/015/421198015.geojson
@@ -219,6 +219,9 @@
     },
     "wof:country":"GN",
     "wof:created":1459009933,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"7f49ac1131e490b6481aa703983333d0",
     "wof:hierarchy":[
         {
@@ -229,7 +232,7 @@
         }
     ],
     "wof:id":421198015,
-    "wof:lastmodified":1566639717,
+    "wof:lastmodified":1582358467,
     "wof:name":"Dinguiraye",
     "wof:parent_id":85671393,
     "wof:placetype":"county",

--- a/data/421/198/017/421198017.geojson
+++ b/data/421/198/017/421198017.geojson
@@ -231,6 +231,9 @@
     },
     "wof:country":"GN",
     "wof:created":1459009933,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"137e2a09ebd92634fe9bd533067cfd33",
     "wof:hierarchy":[
         {
@@ -241,7 +244,7 @@
         }
     ],
     "wof:id":421198017,
-    "wof:lastmodified":1566639718,
+    "wof:lastmodified":1582358467,
     "wof:name":"Siguiri",
     "wof:parent_id":85671489,
     "wof:placetype":"county",

--- a/data/421/199/269/421199269.geojson
+++ b/data/421/199/269/421199269.geojson
@@ -172,6 +172,9 @@
     },
     "wof:country":"GN",
     "wof:created":1459009983,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"836838c9d7a74d2f0106d3dbd04b359f",
     "wof:hierarchy":[
         {
@@ -182,7 +185,7 @@
         }
     ],
     "wof:id":421199269,
-    "wof:lastmodified":1566639719,
+    "wof:lastmodified":1582358468,
     "wof:name":"Boffa",
     "wof:parent_id":85671363,
     "wof:placetype":"county",

--- a/data/421/199/273/421199273.geojson
+++ b/data/421/199/273/421199273.geojson
@@ -124,6 +124,9 @@
     },
     "wof:country":"GN",
     "wof:created":1459009984,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"e77bb491bdd244ec2e28bc8eac60988e",
     "wof:hierarchy":[
         {
@@ -134,7 +137,7 @@
         }
     ],
     "wof:id":421199273,
-    "wof:lastmodified":1566639719,
+    "wof:lastmodified":1582358467,
     "wof:name":"Dubreka",
     "wof:parent_id":85671395,
     "wof:placetype":"county",

--- a/data/421/199/661/421199661.geojson
+++ b/data/421/199/661/421199661.geojson
@@ -178,6 +178,9 @@
     },
     "wof:country":"GN",
     "wof:created":1459009997,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"3b1c6ad5c86c5618a529146cb595b50b",
     "wof:hierarchy":[
         {
@@ -188,7 +191,7 @@
         }
     ],
     "wof:id":421199661,
-    "wof:lastmodified":1566639719,
+    "wof:lastmodified":1582358468,
     "wof:name":"Beyla",
     "wof:parent_id":85671361,
     "wof:placetype":"county",

--- a/data/421/200/003/421200003.geojson
+++ b/data/421/200/003/421200003.geojson
@@ -214,6 +214,9 @@
     },
     "wof:country":"GN",
     "wof:created":1459010008,
+    "wof:geom_alt":[
+        "naturalearth"
+    ],
     "wof:geomhash":"9bef214d08a94f5befa9a482f02c99d7",
     "wof:hierarchy":[
         {
@@ -225,7 +228,7 @@
         }
     ],
     "wof:id":421200003,
-    "wof:lastmodified":1566639719,
+    "wof:lastmodified":1582358468,
     "wof:name":"Kamsar",
     "wof:parent_id":890420105,
     "wof:placetype":"locality",

--- a/data/421/202/513/421202513.geojson
+++ b/data/421/202/513/421202513.geojson
@@ -193,6 +193,9 @@
     },
     "wof:country":"GN",
     "wof:created":1459010120,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"391018499580b1df2e05167edff6f8d5",
     "wof:hierarchy":[
         {
@@ -203,7 +206,7 @@
         }
     ],
     "wof:id":421202513,
-    "wof:lastmodified":1566639715,
+    "wof:lastmodified":1582358466,
     "wof:name":"Coyah",
     "wof:parent_id":85671379,
     "wof:placetype":"county",

--- a/data/421/203/655/421203655.geojson
+++ b/data/421/203/655/421203655.geojson
@@ -181,6 +181,9 @@
     },
     "wof:country":"GN",
     "wof:created":1459010159,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"c1be26363d88f81ce4f22c97cc43a7bc",
     "wof:hierarchy":[
         {
@@ -191,7 +194,7 @@
         }
     ],
     "wof:id":421203655,
-    "wof:lastmodified":1566639715,
+    "wof:lastmodified":1582358466,
     "wof:name":"Kouroussa",
     "wof:parent_id":85671447,
     "wof:placetype":"county",

--- a/data/421/203/701/421203701.geojson
+++ b/data/421/203/701/421203701.geojson
@@ -172,6 +172,9 @@
     },
     "wof:country":"GN",
     "wof:created":1459010161,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"e573fd61f5dbf946709a306bfd6322e9",
     "wof:hierarchy":[
         {
@@ -182,7 +185,7 @@
         }
     ],
     "wof:id":421203701,
-    "wof:lastmodified":1566639715,
+    "wof:lastmodified":1582358466,
     "wof:name":"Yomou",
     "wof:parent_id":85671499,
     "wof:placetype":"county",

--- a/data/421/203/703/421203703.geojson
+++ b/data/421/203/703/421203703.geojson
@@ -178,6 +178,9 @@
     },
     "wof:country":"GN",
     "wof:created":1459010161,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"8235a1e1a3c6668463a3beffb05977ab",
     "wof:hierarchy":[
         {
@@ -188,7 +191,7 @@
         }
     ],
     "wof:id":421203703,
-    "wof:lastmodified":1566639715,
+    "wof:lastmodified":1582358466,
     "wof:name":"Koundara",
     "wof:parent_id":85671443,
     "wof:placetype":"county",

--- a/data/856/326/91/85632691.geojson
+++ b/data/856/326/91/85632691.geojson
@@ -918,8 +918,9 @@
     "qs:source":"US State Department, with Natural Earth mods",
     "src:geom":"quattroshapes",
     "src:geom_alt":[
+        "meso",
         "naturalearth",
-        "meso"
+        "naturalearth"
     ],
     "src:lbl_centroid":"mapshaper",
     "src:population":"wk",
@@ -974,6 +975,11 @@
     },
     "wof:country":"GN",
     "wof:country_alpha3":"GIN",
+    "wof:geom_alt":[
+        "meso",
+        "naturalearth-display-terrestrial-zoom6",
+        "naturalearth"
+    ],
     "wof:geomhash":"2adec76d8cd3f706673435ba32eb58e6",
     "wof:hierarchy":[
         {
@@ -988,7 +994,7 @@
     "wof:lang_x_spoken":[
         "fra"
     ],
-    "wof:lastmodified":1566639291,
+    "wof:lastmodified":1582358457,
     "wof:name":"Guinea",
     "wof:parent_id":102191573,
     "wof:placetype":"country",

--- a/data/856/326/91/85632691.geojson
+++ b/data/856/326/91/85632691.geojson
@@ -919,7 +919,6 @@
     "src:geom":"quattroshapes",
     "src:geom_alt":[
         "meso",
-        "naturalearth",
         "naturalearth"
     ],
     "src:lbl_centroid":"mapshaper",
@@ -994,7 +993,7 @@
     "wof:lang_x_spoken":[
         "fra"
     ],
-    "wof:lastmodified":1582358457,
+    "wof:lastmodified":1583239763,
     "wof:name":"Guinea",
     "wof:parent_id":102191573,
     "wof:placetype":"country",

--- a/data/890/420/101/890420101.geojson
+++ b/data/890/420/101/890420101.geojson
@@ -98,6 +98,9 @@
     },
     "wof:country":"GN",
     "wof:created":1469051318,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"f9131f71fadd1a75175e157a4953d9e6",
     "wof:hierarchy":[
         {
@@ -108,7 +111,7 @@
         }
     ],
     "wof:id":890420101,
-    "wof:lastmodified":1566639726,
+    "wof:lastmodified":1582358468,
     "wof:name":"Dabola",
     "wof:parent_id":85671381,
     "wof:placetype":"county",

--- a/data/890/420/105/890420105.geojson
+++ b/data/890/420/105/890420105.geojson
@@ -113,6 +113,9 @@
     },
     "wof:country":"GN",
     "wof:created":1469051318,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"3e0c67ed705bfe0491706056e03d7e3b",
     "wof:hierarchy":[
         {
@@ -123,7 +126,7 @@
         }
     ],
     "wof:id":890420105,
-    "wof:lastmodified":1566639726,
+    "wof:lastmodified":1582358468,
     "wof:name":"Boke",
     "wof:parent_id":85671367,
     "wof:placetype":"county",

--- a/data/890/429/077/890429077.geojson
+++ b/data/890/429/077/890429077.geojson
@@ -106,6 +106,9 @@
     },
     "wof:country":"GN",
     "wof:created":1469051791,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"111f3c1e840c2828b1d092b9e2eff41b",
     "wof:hierarchy":[
         {
@@ -116,7 +119,7 @@
         }
     ],
     "wof:id":890429077,
-    "wof:lastmodified":1566639726,
+    "wof:lastmodified":1582358468,
     "wof:name":"Kankan",
     "wof:parent_id":85671421,
     "wof:placetype":"county",

--- a/data/890/454/187/890454187.geojson
+++ b/data/890/454/187/890454187.geojson
@@ -92,6 +92,9 @@
     },
     "wof:country":"GN",
     "wof:created":1469052890,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"531dfa3a0711af43d8f5a16e34486141",
     "wof:hierarchy":[
         {
@@ -102,7 +105,7 @@
         }
     ],
     "wof:id":890454187,
-    "wof:lastmodified":1566639723,
+    "wof:lastmodified":1582358468,
     "wof:name":"Koubia",
     "wof:parent_id":85671467,
     "wof:placetype":"county",

--- a/data/890/454/189/890454189.geojson
+++ b/data/890/454/189/890454189.geojson
@@ -157,6 +157,9 @@
     },
     "wof:country":"GN",
     "wof:created":1469052890,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"9d48a822eb211b831258102b207d730a",
     "wof:hierarchy":[
         {
@@ -167,7 +170,7 @@
         }
     ],
     "wof:id":890454189,
-    "wof:lastmodified":1566639723,
+    "wof:lastmodified":1582358468,
     "wof:name":"Lelouma",
     "wof:parent_id":85671455,
     "wof:placetype":"county",

--- a/data/890/455/259/890455259.geojson
+++ b/data/890/455/259/890455259.geojson
@@ -106,6 +106,9 @@
     },
     "wof:country":"GN",
     "wof:created":1469052940,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"09a2fe94e3578c835b42172e72025dd0",
     "wof:hierarchy":[
         {
@@ -116,7 +119,7 @@
         }
     ],
     "wof:id":890455259,
-    "wof:lastmodified":1566639722,
+    "wof:lastmodified":1582358468,
     "wof:name":"Nzerekore",
     "wof:parent_id":85671483,
     "wof:placetype":"county",

--- a/data/890/455/261/890455261.geojson
+++ b/data/890/455/261/890455261.geojson
@@ -167,6 +167,9 @@
     },
     "wof:country":"GN",
     "wof:created":1469052940,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"813db102b283c49a075e95dba786c752",
     "wof:hierarchy":[
         {
@@ -177,7 +180,7 @@
         }
     ],
     "wof:id":890455261,
-    "wof:lastmodified":1566639723,
+    "wof:lastmodified":1582358468,
     "wof:name":"Mali",
     "wof:parent_id":85671467,
     "wof:placetype":"county",

--- a/data/890/455/263/890455263.geojson
+++ b/data/890/455/263/890455263.geojson
@@ -142,6 +142,9 @@
     },
     "wof:country":"GN",
     "wof:created":1469052941,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"01d1a0ef94df874751d1e99f98992b2f",
     "wof:hierarchy":[
         {
@@ -152,7 +155,7 @@
         }
     ],
     "wof:id":890455263,
-    "wof:lastmodified":1566639723,
+    "wof:lastmodified":1582358468,
     "wof:name":"Macenta",
     "wof:parent_id":85671465,
     "wof:placetype":"county",

--- a/data/890/455/267/890455267.geojson
+++ b/data/890/455/267/890455267.geojson
@@ -145,6 +145,9 @@
     },
     "wof:country":"GN",
     "wof:created":1469052941,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"7eeb06e24bdc40b6a708051119079285",
     "wof:hierarchy":[
         {
@@ -155,7 +158,7 @@
         }
     ],
     "wof:id":890455267,
-    "wof:lastmodified":1566639723,
+    "wof:lastmodified":1582358468,
     "wof:name":"Kindia",
     "wof:parent_id":85671429,
     "wof:placetype":"county",


### PR DESCRIPTION
Fixes a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/1793

This PR:

- Adds a new `wof:geom_alt` property to any "default" WOF record that has an alt file, logic [here](https://github.com/whosonfirst-data/whosonfirst-data/issues/1793#issuecomment-587895012)
- Double checks existing `src:geom_alt` properties to ensure all alt file sources are accounted for in the property list. 

This will not require PIP work to update hierarchies.