### PR TITLE
Name updates

### DIFF
--- a/data/421/189/675/421189675.geojson
+++ b/data/421/189/675/421189675.geojson
@@ -31,6 +31,9 @@
     "name:ara_x_preferred":[
         "\u0643\u0648\u0646\u0627\u0643\u0631\u064a"
     ],
+    "name:arz_x_preferred":[
+        "\u0643\u0648\u0646\u0627\u0643\u0631\u0649"
+    ],
     "name:ast_x_preferred":[
         "Conakri"
     ],
@@ -39,6 +42,9 @@
     ],
     "name:bam_x_preferred":[
         "K\u0254nakri"
+    ],
+    "name:bcl_x_preferred":[
+        "Conakry"
     ],
     "name:bel_x_preferred":[
         "\u0413\u043e\u0440\u0430\u0434 \u041a\u043e\u043d\u0430\u043a\u0440\u044b"
@@ -94,11 +100,20 @@
     "name:deu_x_preferred":[
         "Conakry"
     ],
+    "name:diq_x_preferred":[
+        "Conakry"
+    ],
     "name:ell_x_preferred":[
         "\u039a\u03cc\u03bd\u03b1\u03ba\u03c1\u03b9"
     ],
     "name:ell_x_variant":[
         "\u039a\u03bf\u03bd\u03b1\u03ba\u03c1\u03af"
+    ],
+    "name:eng_ca_x_preferred":[
+        "Conakry"
+    ],
+    "name:eng_gb_x_preferred":[
+        "Conakry"
     ],
     "name:eng_x_preferred":[
         "Conakry"
@@ -280,8 +295,14 @@
     "name:nov_x_preferred":[
         "Konakri"
     ],
+    "name:nqo_x_preferred":[
+        "\u07de\u07d0\u07e3\u07ca\u07de\u07d9\u07cc\u07eb"
+    ],
     "name:oci_x_preferred":[
         "Conakry"
+    ],
+    "name:olo_x_preferred":[
+        "Konakri"
     ],
     "name:oss_x_preferred":[
         "\u041a\u043e\u043d\u0430\u043a\u0440\u0438"
@@ -300,6 +321,9 @@
     ],
     "name:por_x_preferred":[
         "Conacri"
+    ],
+    "name:pus_x_preferred":[
+        "\u06a9\u0648\u0646\u0627\u06a9\u0631\u06cc"
     ],
     "name:ron_x_preferred":[
         "Conakry"
@@ -394,6 +418,9 @@
     "name:war_x_preferred":[
         "Conakry"
     ],
+    "name:wol_x_preferred":[
+        "Konakri"
+    ],
     "name:wuu_x_preferred":[
         "\u79d1\u7eb3\u514b\u91cc"
     ],
@@ -408,6 +435,12 @@
     ],
     "name:yue_x_preferred":[
         "\u5eb7\u7d0d\u514b\u7acb"
+    ],
+    "name:zho_hk_x_preferred":[
+        "\u79d1\u7d0d\u514b\u91cc"
+    ],
+    "name:zho_tw_x_preferred":[
+        "\u67ef\u90a3\u514b\u91cc"
     ],
     "name:zho_x_preferred":[
         "\u79d1\u7d0d\u514b\u91cc"
@@ -442,8 +475,8 @@
     "wof:belongsto":[
         102191573,
         85632691,
-        85671395,
-        421191023
+        421191023,
+        85671395
     ],
     "wof:breaches":[],
     "wof:capital_of":85632691,
@@ -473,7 +506,7 @@
         }
     ],
     "wof:id":421189675,
-    "wof:lastmodified":1582358467,
+    "wof:lastmodified":1587427339,
     "wof:name":"Conakry",
     "wof:parent_id":421191023,
     "wof:placetype":"locality",

--- a/data/856/326/91/85632691.geojson
+++ b/data/856/326/91/85632691.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":20.228207,
-    "geom:area_square_m":245933158067.149353,
+    "geom:area_square_m":245933159023.607544,
     "geom:bbox":"-15.394584,7.190909,-7.637853,12.674579",
     "geom:latitude":10.439596,
     "geom:longitude":-10.932205,
@@ -58,6 +58,9 @@
     "name:arg_x_preferred":[
         "Guinea"
     ],
+    "name:ary_x_preferred":[
+        "\u063a\u064a\u0646\u064a\u0627"
+    ],
     "name:arz_x_preferred":[
         "\u062c\u064a\u0646\u064a\u0627"
     ],
@@ -75,6 +78,9 @@
     ],
     "name:bam_x_preferred":[
         "Gine"
+    ],
+    "name:ban_x_preferred":[
+        "Guinea"
     ],
     "name:bcl_x_preferred":[
         "Guineya"
@@ -160,6 +166,12 @@
     "name:dan_x_preferred":[
         "Guinea"
     ],
+    "name:deu_at_x_preferred":[
+        "Guinea"
+    ],
+    "name:deu_ch_x_preferred":[
+        "Guinea"
+    ],
     "name:deu_x_preferred":[
         "Guinea"
     ],
@@ -180,6 +192,12 @@
     ],
     "name:ell_x_preferred":[
         "\u0393\u03bf\u03c5\u03b9\u03bd\u03ad\u03b1"
+    ],
+    "name:eng_ca_x_preferred":[
+        "Guinea"
+    ],
+    "name:eng_gb_x_preferred":[
+        "Guinea"
     ],
     "name:eng_x_preferred":[
         "Guinea"
@@ -248,6 +266,9 @@
     ],
     "name:gag_x_preferred":[
         "Gvineya"
+    ],
+    "name:gcr_x_preferred":[
+        "Gin\u00e9"
     ],
     "name:ger_x_variant":[
         "Republik Guinea"
@@ -477,6 +498,9 @@
     "name:mon_x_preferred":[
         "\u0413\u0432\u0438\u043d\u0435\u0439"
     ],
+    "name:mri_x_preferred":[
+        "Kini"
+    ],
     "name:mrj_x_preferred":[
         "\u0413\u0432\u0438\u043d\u0435\u0439"
     ],
@@ -534,6 +558,9 @@
     "name:nov_x_preferred":[
         "Gini"
     ],
+    "name:nqo_x_preferred":[
+        "\u07d6\u07cc\u07ec\u07e3\u07cd\u07eb"
+    ],
     "name:nso_x_preferred":[
         "Guinea"
     ],
@@ -578,6 +605,9 @@
     ],
     "name:pol_x_preferred":[
         "Gwinea"
+    ],
+    "name:por_br_x_preferred":[
+        "Guin\u00e9"
     ],
     "name:por_x_colloquial":[
         "Guine"
@@ -658,6 +688,9 @@
     "name:sna_x_preferred":[
         "Guinea"
     ],
+    "name:snd_x_preferred":[
+        "\u06af\u0627\u0626\u064a\u0646\u0627"
+    ],
     "name:som_x_preferred":[
         "Guinea"
     ],
@@ -679,6 +712,12 @@
     ],
     "name:srd_x_preferred":[
         "Guinea"
+    ],
+    "name:srp_ec_x_preferred":[
+        "\u0413\u0432\u0438\u043d\u0435\u0458\u0430"
+    ],
+    "name:srp_el_x_preferred":[
+        "Gvineja"
     ],
     "name:srp_x_preferred":[
         "\u0413\u0432\u0438\u043d\u0435\u0458\u0430"
@@ -703,6 +742,9 @@
     ],
     "name:szl_x_preferred":[
         "Gwinyjo"
+    ],
+    "name:szy_x_preferred":[
+        "Guinea"
     ],
     "name:tam_x_preferred":[
         "\u0b95\u0bbf\u0ba9\u0bbf"
@@ -826,8 +868,23 @@
     "name:zha_x_preferred":[
         "Guinea"
     ],
+    "name:zho_cn_x_preferred":[
+        "\u51e0\u5185\u4e9a"
+    ],
+    "name:zho_hk_x_preferred":[
+        "\u757f\u5167\u4e9e"
+    ],
     "name:zho_min_nan_x_preferred":[
         "Guin\u00e9e"
+    ],
+    "name:zho_mo_x_preferred":[
+        "\u757f\u5167\u4e9e"
+    ],
+    "name:zho_sg_x_preferred":[
+        "\u51e0\u5185\u4e9a"
+    ],
+    "name:zho_tw_x_preferred":[
+        "\u5e7e\u5167\u4e9e"
     ],
     "name:zho_x_preferred":[
         "\u51e0\u5185\u4e9a"
@@ -994,7 +1051,7 @@
     "wof:lang_x_spoken":[
         "fra"
     ],
-    "wof:lastmodified":1583797340,
+    "wof:lastmodified":1587427337,
     "wof:name":"Guinea",
     "wof:parent_id":102191573,
     "wof:placetype":"country",


### PR DESCRIPTION
Fixes https://github.com/whosonfirst-data/whosonfirst-data/issues/1796 and https://github.com/whosonfirst-data/whosonfirst-data/issues/1821.

This PR includes:
- Fixes to property values that start or end with `" "`, `\n`, or `\r`, removing those characters.
- Using a modified version of the [wiki names import script](https://github.com/whosonfirst/whosonfirst-cookbook/blob/master/scripts/crawl_to_add_wiki_names.py), adds new `name` properties

There will be ~260 similar PRs, one for each per-country repo. No PIP work require, can merge as-is.