### PR TITLE
gn concordances, placetype local, and more

### DIFF
--- a/data/110/878/462/5/1108784625.geojson
+++ b/data/110/878/462/5/1108784625.geojson
@@ -53,6 +53,7 @@
     "wof:concordances":{
         "hasc:id":"GN.KS"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GN",
     "wof:created":1481764182,
     "wof:geomhash":"3e01e9af432e88f1532125de535e1888",
@@ -65,7 +66,7 @@
         }
     ],
     "wof:id":1108784625,
-    "wof:lastmodified":1694492854,
+    "wof:lastmodified":1695886316,
     "wof:name":"Kissidougo",
     "wof:parent_id":85671435,
     "wof:placetype":"county",

--- a/data/110/878/462/7/1108784627.geojson
+++ b/data/110/878/462/7/1108784627.geojson
@@ -53,6 +53,7 @@
     "wof:concordances":{
         "hasc:id":"GN.TO"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GN",
     "wof:created":1481764190,
     "wof:geomhash":"409cac7966ca5198ca46e0d732734592",
@@ -65,7 +66,7 @@
         }
     ],
     "wof:id":1108784627,
-    "wof:lastmodified":1694492890,
+    "wof:lastmodified":1695886414,
     "wof:name":"Tougue",
     "wof:parent_id":85671497,
     "wof:placetype":"county",

--- a/data/421/167/693/421167693.geojson
+++ b/data/421/167/693/421167693.geojson
@@ -249,6 +249,7 @@
         "hasc:id":"GN.DL",
         "qs_pg:id":140050
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GN",
     "wof:created":1459008740,
     "wof:geom_alt":[
@@ -264,7 +265,7 @@
         }
     ],
     "wof:id":421167693,
-    "wof:lastmodified":1694492941,
+    "wof:lastmodified":1695886069,
     "wof:name":"Dalaba",
     "wof:parent_id":85671385,
     "wof:placetype":"county",

--- a/data/421/175/263/421175263.geojson
+++ b/data/421/175/263/421175263.geojson
@@ -320,6 +320,7 @@
         "wd:id":"Q3077142",
         "wk:page":"For\u00e9cariah"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:coterminous":[
         85671403
     ],
@@ -338,7 +339,7 @@
         }
     ],
     "wof:id":421175263,
-    "wof:lastmodified":1694492941,
+    "wof:lastmodified":1695886069,
     "wof:name":"Forecariah",
     "wof:parent_id":85671403,
     "wof:placetype":"county",

--- a/data/421/180/037/421180037.geojson
+++ b/data/421/180/037/421180037.geojson
@@ -239,6 +239,7 @@
         "wd:id":"Q7862201",
         "wk:page":"T\u00e9lim\u00e9l\u00e9"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:coterminous":[
         85671503
     ],
@@ -257,7 +258,7 @@
         }
     ],
     "wof:id":421180037,
-    "wof:lastmodified":1694492674,
+    "wof:lastmodified":1695886626,
     "wof:name":"Telimele",
     "wof:parent_id":85671503,
     "wof:placetype":"county",

--- a/data/421/182/003/421182003.geojson
+++ b/data/421/182/003/421182003.geojson
@@ -210,6 +210,7 @@
         "wd:id":"Q623145",
         "wk:page":"Lola Prefecture"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GN",
     "wof:created":1459009315,
     "wof:geom_alt":[
@@ -225,7 +226,7 @@
         }
     ],
     "wof:id":421182003,
-    "wof:lastmodified":1694492941,
+    "wof:lastmodified":1695886070,
     "wof:name":"Lola",
     "wof:parent_id":85671461,
     "wof:placetype":"county",

--- a/data/421/182/471/421182471.geojson
+++ b/data/421/182/471/421182471.geojson
@@ -321,6 +321,7 @@
         "hasc:id":"GN.PI",
         "qs_pg:id":913626
     },
+    "wof:concordances_official":"hasc:id",
     "wof:coterminous":[
         85671485
     ],
@@ -339,7 +340,7 @@
         }
     ],
     "wof:id":421182471,
-    "wof:lastmodified":1694492941,
+    "wof:lastmodified":1695886070,
     "wof:name":"Pita",
     "wof:parent_id":85671485,
     "wof:placetype":"county",

--- a/data/421/183/193/421183193.geojson
+++ b/data/421/183/193/421183193.geojson
@@ -179,9 +179,11 @@
     "wof:concordances":{
         "gp:id":56059375,
         "hasc:id":"GN.MM",
+        "iso:code":"GN-MM",
         "qs_pg:id":794917,
         "wd:id":"Q623295"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"GN",
     "wof:created":1459009361,
     "wof:geomhash":"91afc939e551230ae016b98b97617937",
@@ -199,7 +201,7 @@
     "wof:lang_x_spoken":[
         "fra"
     ],
-    "wof:lastmodified":1694493261,
+    "wof:lastmodified":1695884940,
     "wof:name":"Mamou",
     "wof:parent_id":85632691,
     "wof:placetype":"region",

--- a/data/421/183/313/421183313.geojson
+++ b/data/421/183/313/421183313.geojson
@@ -201,6 +201,7 @@
         "wd:id":"Q1470878",
         "wk:page":"Mandiana Prefecture"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GN",
     "wof:created":1459009365,
     "wof:geom_alt":[
@@ -216,7 +217,7 @@
         }
     ],
     "wof:id":421183313,
-    "wof:lastmodified":1694492941,
+    "wof:lastmodified":1695886071,
     "wof:name":"Mandiana",
     "wof:parent_id":85671479,
     "wof:placetype":"county",

--- a/data/421/184/459/421184459.geojson
+++ b/data/421/184/459/421184459.geojson
@@ -213,6 +213,7 @@
         "wd:id":"Q962654",
         "wk:page":"K\u00e9rouan\u00e9 Prefecture"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GN",
     "wof:created":1459009411,
     "wof:geom_alt":[
@@ -228,7 +229,7 @@
         }
     ],
     "wof:id":421184459,
-    "wof:lastmodified":1694492503,
+    "wof:lastmodified":1695885994,
     "wof:name":"Kerouane",
     "wof:parent_id":85671425,
     "wof:placetype":"county",

--- a/data/421/184/941/421184941.geojson
+++ b/data/421/184/941/421184941.geojson
@@ -210,6 +210,7 @@
         "wd:id":"Q1781303",
         "wk:page":"Lab\u00e9 Prefecture"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GN",
     "wof:created":1459009427,
     "wof:geom_alt":[
@@ -225,7 +226,7 @@
         }
     ],
     "wof:id":421184941,
-    "wof:lastmodified":1694492503,
+    "wof:lastmodified":1695885994,
     "wof:name":"Labe",
     "wof:parent_id":85671451,
     "wof:placetype":"county",

--- a/data/421/185/157/421185157.geojson
+++ b/data/421/185/157/421185157.geojson
@@ -222,6 +222,7 @@
         "wd:id":"Q1456064",
         "wk:page":"Fria"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GN",
     "wof:created":1459009434,
     "wof:geom_alt":[
@@ -237,7 +238,7 @@
         }
     ],
     "wof:id":421185157,
-    "wof:lastmodified":1694492941,
+    "wof:lastmodified":1695886071,
     "wof:name":"Fria",
     "wof:parent_id":85671409,
     "wof:placetype":"county",

--- a/data/421/188/373/421188373.geojson
+++ b/data/421/188/373/421188373.geojson
@@ -21,7 +21,7 @@
     ],
     "lbl:min_zoom":8.0,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":1,
     "mz:max_zoom":11.0,
     "mz:min_zoom":8.0,
     "mz:note":"quattroshapes points import (201603)",
@@ -410,11 +410,13 @@
     "wof:concordances":{
         "gn:id":2422464,
         "gp:id":56059372,
+        "iso:code":"GN-C",
         "qs_pg:id":1095745
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"GN",
     "wof:created":1459009548,
-    "wof:geomhash":"a9a532d6ae9be14d8b651632e87d8820",
+    "wof:geomhash":"7aa78aa31a56222104a48f34412f2f94",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -429,7 +431,7 @@
     "wof:lang_x_spoken":[
         "fra"
     ],
-    "wof:lastmodified":1566639717,
+    "wof:lastmodified":1695884281,
     "wof:name":"Conakry",
     "wof:parent_id":85632691,
     "wof:placetype":"region",

--- a/data/421/188/473/421188473.geojson
+++ b/data/421/188/473/421188473.geojson
@@ -177,6 +177,7 @@
         "wd:id":"Q1396210",
         "wk:page":"Faranah Prefecture"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GN",
     "wof:created":1459009559,
     "wof:geom_alt":[
@@ -192,7 +193,7 @@
         }
     ],
     "wof:id":421188473,
-    "wof:lastmodified":1694492941,
+    "wof:lastmodified":1695886069,
     "wof:name":"Faranah",
     "wof:parent_id":85671399,
     "wof:placetype":"county",

--- a/data/421/188/475/421188475.geojson
+++ b/data/421/188/475/421188475.geojson
@@ -180,6 +180,7 @@
         "wd:id":"Q623295",
         "wk:page":"Mamou Prefecture"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GN",
     "wof:created":1459009559,
     "wof:geom_alt":[
@@ -195,7 +196,7 @@
         }
     ],
     "wof:id":421188475,
-    "wof:lastmodified":1694492941,
+    "wof:lastmodified":1695886069,
     "wof:name":"Mamou",
     "wof:parent_id":85671473,
     "wof:placetype":"county",

--- a/data/421/191/023/421191023.geojson
+++ b/data/421/191/023/421191023.geojson
@@ -438,6 +438,7 @@
         "hasc:id":"GN.CK",
         "qs_pg:id":59609
     },
+    "wof:concordances_official":"hasc:id",
     "wof:coterminous":[
         421189675
     ],
@@ -456,7 +457,7 @@
         }
     ],
     "wof:id":421191023,
-    "wof:lastmodified":1694492547,
+    "wof:lastmodified":1695886409,
     "wof:name":"Conakry",
     "wof:parent_id":85671395,
     "wof:placetype":"county",

--- a/data/421/191/557/421191557.geojson
+++ b/data/421/191/557/421191557.geojson
@@ -213,6 +213,7 @@
         "wd:id":"Q614669",
         "wk:page":"Gaoual Prefecture"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GN",
     "wof:created":1459009697,
     "wof:geom_alt":[
@@ -228,7 +229,7 @@
         }
     ],
     "wof:id":421191557,
-    "wof:lastmodified":1694492941,
+    "wof:lastmodified":1695886070,
     "wof:name":"Gaoual",
     "wof:parent_id":85671413,
     "wof:placetype":"county",

--- a/data/421/191/559/421191559.geojson
+++ b/data/421/191/559/421191559.geojson
@@ -210,6 +210,7 @@
         "wd:id":"Q623142",
         "wk:page":"Gu\u00e9ck\u00e9dou Prefecture"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GN",
     "wof:created":1459009697,
     "wof:geom_alt":[
@@ -225,7 +226,7 @@
         }
     ],
     "wof:id":421191559,
-    "wof:lastmodified":1694492941,
+    "wof:lastmodified":1695886070,
     "wof:name":"Gueckedou",
     "wof:parent_id":85671417,
     "wof:placetype":"county",

--- a/data/421/192/849/421192849.geojson
+++ b/data/421/192/849/421192849.geojson
@@ -286,13 +286,15 @@
         "gn:id":2421272,
         "gp:id":56059379,
         "hasc:id":"GN.FA",
+        "iso:code":"GN-FA",
         "iso:id":"GN-FA",
         "qs_pg:id":1181313,
         "wd:id":"Q597843"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"GN",
     "wof:created":1459009750,
-    "wof:geomhash":"114b82e76332d79916803d05985b3a2f",
+    "wof:geomhash":"05fcb1021e14b6483670741477d8dc6b",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -307,7 +309,7 @@
     "wof:lang_x_spoken":[
         "fra"
     ],
-    "wof:lastmodified":1690921887,
+    "wof:lastmodified":1695884940,
     "wof:name":"Faranah",
     "wof:parent_id":85632691,
     "wof:placetype":"region",

--- a/data/421/198/015/421198015.geojson
+++ b/data/421/198/015/421198015.geojson
@@ -278,6 +278,7 @@
         "wd:id":"Q1006013",
         "wk:page":"Dinguiraye"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:coterminous":[
         85671393
     ],
@@ -296,7 +297,7 @@
         }
     ],
     "wof:id":421198015,
-    "wof:lastmodified":1694492941,
+    "wof:lastmodified":1695886069,
     "wof:name":"Dinguiraye",
     "wof:parent_id":85671393,
     "wof:placetype":"county",

--- a/data/421/198/017/421198017.geojson
+++ b/data/421/198/017/421198017.geojson
@@ -296,6 +296,7 @@
         "wd:id":"Q1100303",
         "wk:page":"Siguiri"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:coterminous":[
         85671489
     ],
@@ -314,7 +315,7 @@
         }
     ],
     "wof:id":421198017,
-    "wof:lastmodified":1694492941,
+    "wof:lastmodified":1695886070,
     "wof:name":"Siguiri",
     "wof:parent_id":85671489,
     "wof:placetype":"county",

--- a/data/421/199/269/421199269.geojson
+++ b/data/421/199/269/421199269.geojson
@@ -207,6 +207,7 @@
         "wd:id":"Q890340",
         "wk:page":"Boffa Prefecture"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GN",
     "wof:created":1459009983,
     "wof:geom_alt":[
@@ -222,7 +223,7 @@
         }
     ],
     "wof:id":421199269,
-    "wof:lastmodified":1694492941,
+    "wof:lastmodified":1695886070,
     "wof:name":"Boffa",
     "wof:parent_id":85671363,
     "wof:placetype":"county",

--- a/data/421/199/273/421199273.geojson
+++ b/data/421/199/273/421199273.geojson
@@ -150,6 +150,7 @@
         "wd:id":"Q985362",
         "wk:page":"Dubr\u00e9ka"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:coterminous":[
         85671395
     ],
@@ -168,7 +169,7 @@
         }
     ],
     "wof:id":421199273,
-    "wof:lastmodified":1694492547,
+    "wof:lastmodified":1695886409,
     "wof:name":"Dubreka",
     "wof:parent_id":85671395,
     "wof:placetype":"county",

--- a/data/421/199/661/421199661.geojson
+++ b/data/421/199/661/421199661.geojson
@@ -216,6 +216,7 @@
         "wd:id":"Q853169",
         "wk:page":"Beyla Prefecture"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GN",
     "wof:created":1459009997,
     "wof:geom_alt":[
@@ -231,7 +232,7 @@
         }
     ],
     "wof:id":421199661,
-    "wof:lastmodified":1694492941,
+    "wof:lastmodified":1695886070,
     "wof:name":"Beyla",
     "wof:parent_id":85671361,
     "wof:placetype":"county",

--- a/data/421/202/513/421202513.geojson
+++ b/data/421/202/513/421202513.geojson
@@ -213,6 +213,7 @@
         "wd:id":"Q1021470",
         "wk:page":"Coyah"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GN",
     "wof:created":1459010120,
     "wof:geom_alt":[
@@ -228,7 +229,7 @@
         }
     ],
     "wof:id":421202513,
-    "wof:lastmodified":1694492941,
+    "wof:lastmodified":1695886070,
     "wof:name":"Coyah",
     "wof:parent_id":85671379,
     "wof:placetype":"county",

--- a/data/421/203/655/421203655.geojson
+++ b/data/421/203/655/421203655.geojson
@@ -222,6 +222,7 @@
         "wd:id":"Q1471573",
         "wk:page":"Kouroussa Prefecture"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:coterminous":[
         85671447
     ],
@@ -240,7 +241,7 @@
         }
     ],
     "wof:id":421203655,
-    "wof:lastmodified":1694492941,
+    "wof:lastmodified":1695886070,
     "wof:name":"Kouroussa",
     "wof:parent_id":85671447,
     "wof:placetype":"county",

--- a/data/421/203/701/421203701.geojson
+++ b/data/421/203/701/421203701.geojson
@@ -195,6 +195,7 @@
         "wd:id":"Q623139",
         "wk:page":"Yomou Prefecture"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GN",
     "wof:created":1459010161,
     "wof:geom_alt":[
@@ -210,7 +211,7 @@
         }
     ],
     "wof:id":421203701,
-    "wof:lastmodified":1694492941,
+    "wof:lastmodified":1695886069,
     "wof:name":"Yomou",
     "wof:parent_id":85671499,
     "wof:placetype":"county",

--- a/data/421/203/703/421203703.geojson
+++ b/data/421/203/703/421203703.geojson
@@ -216,6 +216,7 @@
         "wd:id":"Q1781312",
         "wk:page":"Koundara Prefecture"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GN",
     "wof:created":1459010161,
     "wof:geom_alt":[
@@ -231,7 +232,7 @@
         }
     ],
     "wof:id":421203703,
-    "wof:lastmodified":1694492941,
+    "wof:lastmodified":1695886069,
     "wof:name":"Koundara",
     "wof:parent_id":85671443,
     "wof:placetype":"county",

--- a/data/856/326/91/85632691.geojson
+++ b/data/856/326/91/85632691.geojson
@@ -1156,6 +1156,7 @@
         "hasc:id":"GN",
         "icao:code":"3X",
         "ioc:id":"GUI",
+        "iso:code":"GN",
         "itu:id":"GUI",
         "loc:id":"n79088885",
         "m49:code":"324",
@@ -1170,6 +1171,7 @@
         "wk:page":"Guinea",
         "wmo:id":"GN"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"GN",
     "wof:country_alpha3":"GIN",
     "wof:geom_alt":[
@@ -1191,7 +1193,7 @@
     "wof:lang_x_spoken":[
         "fra"
     ],
-    "wof:lastmodified":1694639556,
+    "wof:lastmodified":1695881214,
     "wof:name":"Guinea",
     "wof:parent_id":102191573,
     "wof:placetype":"country",

--- a/data/856/713/61/85671361.geojson
+++ b/data/856/713/61/85671361.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.038856,
-    "geom:area_square_m":12694366050.433617,
+    "geom:area_square_m":12694366196.452145,
     "geom:bbox":"-8.969148,8.015171,-7.662447,9.418651",
     "geom:latitude":8.796998,
     "geom:longitude":-8.344479,
@@ -215,12 +215,14 @@
         "gn:id":2423124,
         "gp:id":-56059376,
         "hasc:id":"GN.BE",
+        "iso:code":"GN-BE",
         "iso:id":"GN-BE",
         "unlc:id":"GN-BE",
         "wd:id":"Q3048208"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"GN",
-    "wof:geomhash":"926fe0efb6d4ed618a80664f6a9e8ca8",
+    "wof:geomhash":"aed305d7ba0140d304c1dd1c45ddb7f3",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -235,7 +237,7 @@
     "wof:lang_x_spoken":[
         "fra"
     ],
-    "wof:lastmodified":1690921870,
+    "wof:lastmodified":1695884939,
     "wof:name":"Beyla",
     "wof:parent_id":85632691,
     "wof:placetype":"region",

--- a/data/856/713/63/85671363.geojson
+++ b/data/856/713/63/85671363.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.420947,
-    "geom:area_square_m":5119969220.792464,
+    "geom:area_square_m":5119969678.894586,
     "geom:bbox":"-14.550893,9.850043,-13.612442,10.740843",
     "geom:latitude":10.373918,
     "geom:longitude":-14.059591,
@@ -236,12 +236,14 @@
         "gn:id":2422967,
         "gp:id":-56059373,
         "hasc:id":"GN.BF",
+        "iso:code":"GN-BF",
         "iso:id":"GN-BF",
         "unlc:id":"GN-BF",
         "wd:id":"Q2908600"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"GN",
-    "wof:geomhash":"d467b636b87d970a3beb10e35191c66b",
+    "wof:geomhash":"a3608a1a05d52d3a6104c7720a982a54",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -256,7 +258,7 @@
     "wof:lang_x_spoken":[
         "fra"
     ],
-    "wof:lastmodified":1690921872,
+    "wof:lastmodified":1695884939,
     "wof:name":"Boffa",
     "wof:parent_id":85632691,
     "wof:placetype":"region",

--- a/data/856/713/67/85671367.geojson
+++ b/data/856/713/67/85671367.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.896531,
-    "geom:area_square_m":10878100028.119951,
+    "geom:area_square_m":10878101043.967916,
     "geom:bbox":"-15.081125,10.473375,-13.758767,11.66885",
     "geom:latitude":11.104419,
     "geom:longitude":-14.364229,
@@ -218,11 +218,13 @@
         "gn:id":2422923,
         "gp:id":-56059373,
         "hasc:id":"GN.BK",
+        "iso:code":"GN-BK",
         "iso:id":"GN-BK",
         "wd:id":"Q891238"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"GN",
-    "wof:geomhash":"e30da1d77584dc35ad1720072d256bb3",
+    "wof:geomhash":"22add1028c299b053e1e6da015c42932",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -237,7 +239,7 @@
     "wof:lang_x_spoken":[
         "fra"
     ],
-    "wof:lastmodified":1690921870,
+    "wof:lastmodified":1695884939,
     "wof:name":"Boke",
     "wof:parent_id":85632691,
     "wof:placetype":"region",

--- a/data/856/713/73/85671373.geojson
+++ b/data/856/713/73/85671373.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.002042,
-    "geom:area_square_m":24903560.373046,
+    "geom:area_square_m":24903560.373045,
     "geom:bbox":"-13.7262263663,9.50580475509,-13.6432669967,9.57390613556",
     "geom:latitude":9.53811,
     "geom:longitude":-13.682231,
@@ -489,10 +489,12 @@
         "gn:id":2422464,
         "gp:id":-56059372,
         "hasc:id":"GN.CK",
+        "iso:code":"GN-C",
         "iso:id":"GN-C"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"GN",
-    "wof:geomhash":"0903c8061a6072158b17b10c943c4243",
+    "wof:geomhash":"d7b4b45e7ae2a11b89f46db99906d5e9",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -507,7 +509,7 @@
     "wof:lang_x_spoken":[
         "fra"
     ],
-    "wof:lastmodified":1566639286,
+    "wof:lastmodified":1695884326,
     "wof:name":"Conakry",
     "wof:parent_id":85632691,
     "wof:placetype":"region",

--- a/data/856/713/79/85671379.geojson
+++ b/data/856/713/79/85671379.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.117652,
-    "geom:area_square_m":1433724421.661645,
+    "geom:area_square_m":1433724629.55682,
     "geom:bbox":"-13.528193,9.524482,-13.089549,9.998574",
     "geom:latitude":9.760566,
     "geom:longitude":-13.329521,
@@ -257,12 +257,14 @@
         "gn:id":2595299,
         "gp:id":-56059377,
         "hasc:id":"GN.CO",
+        "iso:code":"GN-CO",
         "iso:id":"GN-CO",
         "unlc:id":"GN-CO",
         "wd:id":"Q1021470"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"GN",
-    "wof:geomhash":"13a994d53da7f3bc3dd01a1f002c924c",
+    "wof:geomhash":"d873b25461525089d62b6501bbd683d1",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -277,7 +279,7 @@
     "wof:lang_x_spoken":[
         "fra"
     ],
-    "wof:lastmodified":1690921872,
+    "wof:lastmodified":1695884939,
     "wof:name":"Coyah",
     "wof:parent_id":85632691,
     "wof:placetype":"region",

--- a/data/856/713/81/85671381.geojson
+++ b/data/856/713/81/85671381.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.495574,
-    "geom:area_square_m":6021777998.089458,
+    "geom:area_square_m":6021777998.089483,
     "geom:bbox":"-11.606406,9.994283,-10.598107,11.112552",
     "geom:latitude":10.673737,
     "geom:longitude":-11.238334,
@@ -205,14 +205,16 @@
         "gn:id":2422441,
         "gp:id":-56059379,
         "hasc:id":"GN.DB",
+        "iso:code":"GN-DB",
         "iso:id":"GN-DB",
         "unlc:id":"GN-DB"
     },
+    "wof:concordances_official":"iso:code",
     "wof:coterminous":[
         890420101
     ],
     "wof:country":"GN",
-    "wof:geomhash":"75145b1ea2a9709eda0b10aabe512fb8",
+    "wof:geomhash":"15c0c24570c1ae141bdb372f48529ca0",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -227,7 +229,7 @@
     "wof:lang_x_spoken":[
         "fra"
     ],
-    "wof:lastmodified":1636502717,
+    "wof:lastmodified":1695884939,
     "wof:name":"Dabola",
     "wof:parent_id":85632691,
     "wof:placetype":"region",

--- a/data/856/713/85/85671385.geojson
+++ b/data/856/713/85/85671385.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.317669,
-    "geom:area_square_m":3857662684.725983,
+    "geom:area_square_m":3857661625.109597,
     "geom:bbox":"-12.649532,10.491246,-11.779628,11.305977",
     "geom:latitude":10.860908,
     "geom:longitude":-12.193326,
@@ -224,12 +224,14 @@
         "gn:id":2422377,
         "gp:id":-56059375,
         "hasc:id":"GN.DL",
+        "iso:code":"GN-DL",
         "iso:id":"GN-DL",
         "unlc:id":"GN-DL",
         "wd:id":"Q984798"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"GN",
-    "wof:geomhash":"788fa2839c23302547bdc9cc89e0bc1c",
+    "wof:geomhash":"e3c07fbbd843a981395e2a3ecaf5b199",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -244,7 +246,7 @@
     "wof:lang_x_spoken":[
         "fra"
     ],
-    "wof:lastmodified":1690921873,
+    "wof:lastmodified":1695884939,
     "wof:name":"Dalaba",
     "wof:parent_id":85632691,
     "wof:placetype":"region",

--- a/data/856/713/93/85671393.geojson
+++ b/data/856/713/93/85671393.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.074948,
-    "geom:area_square_m":13019426765.176119,
+    "geom:area_square_m":13019426765.17605,
     "geom:bbox":"-11.423079,10.944963,-9.888772,12.219462",
     "geom:latitude":11.617804,
     "geom:longitude":-10.683534,
@@ -230,15 +230,17 @@
         "gn:id":2421902,
         "gp:id":-56059379,
         "hasc:id":"GN.DI",
+        "iso:code":"GN-DI",
         "iso:id":"GN-DI",
         "unlc:id":"GN-DI",
         "wd:id":"Q1006013"
     },
+    "wof:concordances_official":"iso:code",
     "wof:coterminous":[
         421198015
     ],
     "wof:country":"GN",
-    "wof:geomhash":"fabb7699115cebbe4b4ac342b53c9923",
+    "wof:geomhash":"3c85e855087cd3800bd2adf44f7a4184",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -253,7 +255,7 @@
     "wof:lang_x_spoken":[
         "fra"
     ],
-    "wof:lastmodified":1690921871,
+    "wof:lastmodified":1695884939,
     "wof:name":"Dinguiraye",
     "wof:parent_id":85632691,
     "wof:placetype":"region",

--- a/data/856/713/95/85671395.geojson
+++ b/data/856/713/95/85671395.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.300614,
-    "geom:area_square_m":3659991322.424383,
+    "geom:area_square_m":3659991322.424393,
     "geom:bbox":"-13.913435,9.50019,-13.113585,10.404169",
     "geom:latitude":10.058967,
     "geom:longitude":-13.517581,
@@ -194,15 +194,17 @@
         "gn:id":2421533,
         "gp:id":-56059377,
         "hasc:id":"GN.DU",
+        "iso:code":"GN-DU",
         "iso:id":"GN-DU",
         "unlc:id":"GN-DU",
         "wd:id":"Q985362"
     },
+    "wof:concordances_official":"iso:code",
     "wof:coterminous":[
         421199273
     ],
     "wof:country":"GN",
-    "wof:geomhash":"0057ecff6ae67a21b780d5af344160ed",
+    "wof:geomhash":"9c1932111262e2a4e7a54f292e548c17",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -217,7 +219,7 @@
     "wof:lang_x_spoken":[
         "fra"
     ],
-    "wof:lastmodified":1690921870,
+    "wof:lastmodified":1695884473,
     "wof:name":"Dubr\u00e9ka",
     "wof:parent_id":85632691,
     "wof:placetype":"region",

--- a/data/856/713/99/85671399.geojson
+++ b/data/856/713/99/85671399.geojson
@@ -223,8 +223,10 @@
     "wof:concordances":{
         "gp:id":56059379,
         "hasc:id":"GN.FA",
+        "iso:code":"GN-FA",
         "wd:id":"Q597843"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"GN",
     "wof:geomhash":"5c89f6949e6784cd733b7f83e127fe5b",
     "wof:hierarchy":[
@@ -241,7 +243,7 @@
     "wof:lang_x_spoken":[
         "fra"
     ],
-    "wof:lastmodified":1694639831,
+    "wof:lastmodified":1695884286,
     "wof:name":"Faranah",
     "wof:parent_id":85632691,
     "wof:placetype":"region",

--- a/data/856/714/03/85671403.geojson
+++ b/data/856/714/03/85671403.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.330361,
-    "geom:area_square_m":4029926600.390362,
+    "geom:area_square_m":4029926600.390374,
     "geom:bbox":"-13.520863,9.041465,-12.601552,9.698134",
     "geom:latitude":9.416291,
     "geom:longitude":-13.069032,
@@ -251,15 +251,17 @@
         "gn:id":2420983,
         "gp:id":-56059377,
         "hasc:id":"GN.FO",
+        "iso:code":"GN-FO",
         "iso:id":"GN-FO",
         "unlc:id":"GN-FO",
         "wd:id":"Q3077142"
     },
+    "wof:concordances_official":"iso:code",
     "wof:coterminous":[
         421175263
     ],
     "wof:country":"GN",
-    "wof:geomhash":"66ba221b51d9b0a2d8c02397ccfe3d8f",
+    "wof:geomhash":"d0ec764bb34ea9afb9156439bb964461",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -274,7 +276,7 @@
     "wof:lang_x_spoken":[
         "fra"
     ],
-    "wof:lastmodified":1690921873,
+    "wof:lastmodified":1695884473,
     "wof:name":"For\u00e9cariah",
     "wof:parent_id":85632691,
     "wof:placetype":"region",

--- a/data/856/714/09/85671409.geojson
+++ b/data/856/714/09/85671409.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.195008,
-    "geom:area_square_m":2371168899.389821,
+    "geom:area_square_m":2371170543.742849,
     "geom:bbox":"-13.828634,10.239199,-13.19629,10.714778",
     "geom:latitude":10.467728,
     "geom:longitude":-13.493696,
@@ -269,12 +269,14 @@
         "gn:id":2420883,
         "gp:id":-56059373,
         "hasc:id":"GN.FR",
+        "iso:code":"GN-FR",
         "iso:id":"GN-FR",
         "unlc:id":"GN-FR",
         "wd:id":"Q1456064"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"GN",
-    "wof:geomhash":"4b34f984311af6eb574532fed9e64743",
+    "wof:geomhash":"9e5db9878372fc662cde5936c1193282",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -289,7 +291,7 @@
     "wof:lang_x_spoken":[
         "fra"
     ],
-    "wof:lastmodified":1690921877,
+    "wof:lastmodified":1695884940,
     "wof:name":"Fria",
     "wof:parent_id":85632691,
     "wof:placetype":"region",

--- a/data/856/714/13/85671413.geojson
+++ b/data/856/714/13/85671413.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.916696,
-    "geom:area_square_m":11098638373.829258,
+    "geom:area_square_m":11098640971.188702,
     "geom:bbox":"-14.047955,11.129476,-12.704154,12.310858",
     "geom:latitude":11.721226,
     "geom:longitude":-13.359717,
@@ -236,12 +236,14 @@
         "gn:id":2420825,
         "gp:id":-56059373,
         "hasc:id":"GN.GA",
+        "iso:code":"GN-GA",
         "iso:id":"GN-GA",
         "unlc:id":"GN-GA",
         "wd:id":"Q3095240"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"GN",
-    "wof:geomhash":"c1610dea430a5b1a74a95311c492644e",
+    "wof:geomhash":"db28ca6fcc30f5fc51e53107e86fa4d0",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -256,7 +258,7 @@
     "wof:lang_x_spoken":[
         "fra"
     ],
-    "wof:lastmodified":1690921881,
+    "wof:lastmodified":1695884940,
     "wof:name":"Gaoual",
     "wof:parent_id":85632691,
     "wof:placetype":"region",

--- a/data/856/714/17/85671417.geojson
+++ b/data/856/714/17/85671417.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.381012,
-    "geom:area_square_m":4656910446.996481,
+    "geom:area_square_m":4656911541.906418,
     "geom:bbox":"-10.735283,8.2696,-9.769992,9.185176",
     "geom:latitude":8.710929,
     "geom:longitude":-10.282701,
@@ -290,11 +290,13 @@
         "gn:id":2420561,
         "gp:id":-56059376,
         "hasc:id":"GN.GU",
+        "iso:code":"GN-GU",
         "iso:id":"GN-GU",
         "wd:id":"Q740687"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"GN",
-    "wof:geomhash":"53c3bade2b2a50325e4455b822dce9c1",
+    "wof:geomhash":"7d6eda66fc351e7d0e9a187ff52a6144",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -309,7 +311,7 @@
     "wof:lang_x_spoken":[
         "fra"
     ],
-    "wof:lastmodified":1690921876,
+    "wof:lastmodified":1695884505,
     "wof:name":"Gu\u00e9ck\u00e9dou",
     "wof:parent_id":85632691,
     "wof:placetype":"region",

--- a/data/856/714/21/85671421.geojson
+++ b/data/856/714/21/85671421.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.400264,
-    "geom:area_square_m":17051384788.929808,
+    "geom:area_square_m":17051382378.962696,
     "geom:bbox":"-9.955201,9.335173,-8.070433,10.749676",
     "geom:latitude":9.9971,
     "geom:longitude":-9.049288,
@@ -265,11 +265,13 @@
         "gn:id":2419991,
         "gp:id":-56059378,
         "hasc:id":"GN.KA",
+        "iso:code":"GN-KA",
         "iso:id":"GN-KA",
         "wd:id":"Q581719"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"GN",
-    "wof:geomhash":"d99db55ebf86e1c060b7c8740f9ae471",
+    "wof:geomhash":"471fe3acc92e055a2b3a688c0af0a3aa",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -284,7 +286,7 @@
     "wof:lang_x_spoken":[
         "fra"
     ],
-    "wof:lastmodified":1690921876,
+    "wof:lastmodified":1695884940,
     "wof:name":"Kankan",
     "wof:parent_id":85632691,
     "wof:placetype":"region",

--- a/data/856/714/25/85671425.geojson
+++ b/data/856/714/25/85671425.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.470481,
-    "geom:area_square_m":5740371160.851863,
+    "geom:area_square_m":5740371372.353653,
     "geom:bbox":"-9.3361,8.910652,-8.465766,9.740195",
     "geom:latitude":9.343519,
     "geom:longitude":-8.923871,
@@ -185,12 +185,14 @@
         "gn:id":2419618,
         "gp:id":-56059378,
         "hasc:id":"GN.KE",
+        "iso:code":"GN-KE",
         "iso:id":"GN-KE",
         "unlc:id":"GN-KE",
         "wd:id":"Q1152900"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"GN",
-    "wof:geomhash":"d80bba68ca7d55bf2ace0e46e0f62eef",
+    "wof:geomhash":"5e0054ad467d63a3ead347e377ebacbb",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -205,7 +207,7 @@
     "wof:lang_x_spoken":[
         "fra"
     ],
-    "wof:lastmodified":1690921882,
+    "wof:lastmodified":1695884326,
     "wof:name":"K\u00e9rouan\u00e9",
     "wof:parent_id":85632691,
     "wof:placetype":"region",

--- a/data/856/714/29/85671429.geojson
+++ b/data/856/714/29/85671429.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.706445,
-    "geom:area_square_m":8600325563.520611,
+    "geom:area_square_m":8600325563.520605,
     "geom:bbox":"-13.281831,9.562935,-12.109807,10.619042",
     "geom:latitude":10.083633,
     "geom:longitude":-12.733217,
@@ -244,14 +244,16 @@
         "gn:id":2419531,
         "gp:id":-56059377,
         "hasc:id":"GN.KD",
+        "iso:code":"GN-KD",
         "iso:id":"GN-KD",
         "wd:id":"Q1741960"
     },
+    "wof:concordances_official":"iso:code",
     "wof:coterminous":[
         890455267
     ],
     "wof:country":"GN",
-    "wof:geomhash":"b73c46ea34993e0e7d84c02ed75d4d0a",
+    "wof:geomhash":"d60e20f920989bfad96cc442fbea686f",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -266,7 +268,7 @@
     "wof:lang_x_spoken":[
         "fra"
     ],
-    "wof:lastmodified":1690921875,
+    "wof:lastmodified":1695884939,
     "wof:name":"Kindia",
     "wof:parent_id":85632691,
     "wof:placetype":"region",

--- a/data/856/714/35/85671435.geojson
+++ b/data/856/714/35/85671435.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.743398,
-    "geom:area_square_m":9072564750.378317,
+    "geom:area_square_m":9072563443.529739,
     "geom:bbox":"-10.478244,8.860002,-9.221203,9.716565",
     "geom:latitude":9.254319,
     "geom:longitude":-9.882043,
@@ -275,12 +275,14 @@
         "gn:id":2419470,
         "gp:id":-56059379,
         "hasc:id":"GN.KS",
+        "iso:code":"GN-KS",
         "iso:id":"GN-KS",
         "unlc:id":"GN-KS",
         "wd:id":"Q1358885"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"GN",
-    "wof:geomhash":"838223ea34bb11949522a5ae4de53b20",
+    "wof:geomhash":"c6d9deb0e65699cb5bb4a0791f4bc38e",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -295,7 +297,7 @@
     "wof:lang_x_spoken":[
         "fra"
     ],
-    "wof:lastmodified":1690921874,
+    "wof:lastmodified":1695884939,
     "wof:name":"Kissidougou",
     "wof:parent_id":85632691,
     "wof:placetype":"region",

--- a/data/856/714/37/85671437.geojson
+++ b/data/856/714/37/85671437.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.279113,
-    "geom:area_square_m":3380151641.830213,
+    "geom:area_square_m":3380150385.299905,
     "geom:bbox":"-12.31747,11.285668,-11.343989,12.134609",
     "geom:latitude":11.652988,
     "geom:longitude":-11.765606,
@@ -182,12 +182,14 @@
         "gn:id":2595302,
         "gp:id":-56059374,
         "hasc:id":"GN.KB",
+        "iso:code":"GN-KB",
         "iso:id":"GN-KB",
         "unlc:id":"GN-KB",
         "wd:id":"Q3199237"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"GN",
-    "wof:geomhash":"dbf5bc4de93c34f5f5984b0f0f814a49",
+    "wof:geomhash":"91f1de3fca858270d0c4c91d2040e2bb",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -202,7 +204,7 @@
     "wof:lang_x_spoken":[
         "fra"
     ],
-    "wof:lastmodified":1690921878,
+    "wof:lastmodified":1695884940,
     "wof:name":"Koubia",
     "wof:parent_id":85632691,
     "wof:placetype":"region",

--- a/data/856/714/43/85671443.geojson
+++ b/data/856/714/43/85671443.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.442556,
-    "geom:area_square_m":5345252942.297502,
+    "geom:area_square_m":5345254327.437759,
     "geom:bbox":"-13.736314,12.015428,-12.57813,12.673388",
     "geom:latitude":12.368903,
     "geom:longitude":-13.209604,
@@ -230,12 +230,14 @@
         "gn:id":2418595,
         "gp:id":-56059373,
         "hasc:id":"GN.KN",
+        "iso:code":"GN-KN",
         "iso:id":"GN-KN",
         "unlc:id":"GN-KN",
         "wd:id":"Q985374"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"GN",
-    "wof:geomhash":"e8d5f6a117aee077bee86aa3540bd069",
+    "wof:geomhash":"41082f3a8402119471d76d83ff6442eb",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -250,7 +252,7 @@
     "wof:lang_x_spoken":[
         "fra"
     ],
-    "wof:lastmodified":1690921876,
+    "wof:lastmodified":1695884940,
     "wof:name":"Koundara",
     "wof:parent_id":85632691,
     "wof:placetype":"region",

--- a/data/856/714/47/85671447.geojson
+++ b/data/856/714/47/85671447.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.318322,
-    "geom:area_square_m":16022694700.581007,
+    "geom:area_square_m":16022694700.580992,
     "geom:bbox":"-10.897856,9.595823,-9.343053,11.466543",
     "geom:latitude":10.598758,
     "geom:longitude":-10.100592,
@@ -218,15 +218,17 @@
         "gn:id":2418435,
         "gp:id":-56059378,
         "hasc:id":"GN.KO",
+        "iso:code":"GN-KO",
         "iso:id":"GN-KO",
         "unlc:id":"GN-KO",
         "wd:id":"Q731232"
     },
+    "wof:concordances_official":"iso:code",
     "wof:coterminous":[
         421203655
     ],
     "wof:country":"GN",
-    "wof:geomhash":"35d977761213df9299c57459a7c4df27",
+    "wof:geomhash":"6c42e6763e923f0975a5f5b0b6520bfc",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -241,7 +243,7 @@
     "wof:lang_x_spoken":[
         "fra"
     ],
-    "wof:lastmodified":1690921881,
+    "wof:lastmodified":1695884940,
     "wof:name":"Kouroussa",
     "wof:parent_id":85632691,
     "wof:placetype":"region",

--- a/data/856/714/51/85671451.geojson
+++ b/data/856/714/51/85671451.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.169177,
-    "geom:area_square_m":2050437987.616956,
+    "geom:area_square_m":2050435213.274369,
     "geom:bbox":"-12.525667,11.148415,-12.055486,11.727772",
     "geom:latitude":11.425508,
     "geom:longitude":-12.335601,
@@ -258,11 +258,13 @@
         "gn:id":2418360,
         "gp:id":-56059374,
         "hasc:id":"GN.LA",
+        "iso:code":"GN-LA",
         "iso:id":"GN-LA",
         "wd:id":"Q1781303"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"GN",
-    "wof:geomhash":"2d96e3f04f4911ee3e349dfac580385e",
+    "wof:geomhash":"dcbfb01801ad8e0b0bce8a6c0f2efd57",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -277,7 +279,7 @@
     "wof:lang_x_spoken":[
         "fra"
     ],
-    "wof:lastmodified":1690921874,
+    "wof:lastmodified":1695884326,
     "wof:name":"Lab\u00e9",
     "wof:parent_id":85632691,
     "wof:placetype":"region",

--- a/data/856/714/55/85671455.geojson
+++ b/data/856/714/55/85671455.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.194391,
-    "geom:area_square_m":2356252864.292421,
+    "geom:area_square_m":2356254509.505245,
     "geom:bbox":"-12.989718,10.985867,-12.461628,11.725678",
     "geom:latitude":11.400202,
     "geom:longitude":-12.722418,
@@ -176,12 +176,14 @@
         "gn:id":2595303,
         "gp:id":-56059374,
         "hasc:id":"GN.LE",
+        "iso:code":"GN-LE",
         "iso:id":"GN-LE",
         "unlc:id":"GN-LE",
         "wd:id":"Q3270350"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"GN",
-    "wof:geomhash":"19f75ae4a36533cf53d16eb558b81c98",
+    "wof:geomhash":"c82a7cbd261033d2c51edec49c673987",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -196,7 +198,7 @@
     "wof:lang_x_spoken":[
         "fra"
     ],
-    "wof:lastmodified":1690921879,
+    "wof:lastmodified":1695884326,
     "wof:name":"L\u00e9louma",
     "wof:parent_id":85632691,
     "wof:placetype":"region",

--- a/data/856/714/61/85671461.geojson
+++ b/data/856/714/61/85671461.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.23562,
-    "geom:area_square_m":2886005284.425188,
+    "geom:area_square_m":2886005815.330651,
     "geom:bbox":"-8.57278,7.544295,-8.067229,8.219965",
     "geom:latitude":7.873139,
     "geom:longitude":-8.328075,
@@ -215,12 +215,14 @@
         "gn:id":2595304,
         "gp:id":-56059376,
         "hasc:id":"GN.LO",
+        "iso:code":"GN-LO",
         "iso:id":"GN-LO",
         "unlc:id":"GN-LO",
         "wd:id":"Q229004"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"GN",
-    "wof:geomhash":"c0d4348b1963b52cd064f19dc737a1b4",
+    "wof:geomhash":"dd6b353febc95e0da30ed7f026ea5da8",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -235,7 +237,7 @@
     "wof:lang_x_spoken":[
         "fra"
     ],
-    "wof:lastmodified":1690921873,
+    "wof:lastmodified":1695884940,
     "wof:name":"Lola",
     "wof:parent_id":85632691,
     "wof:placetype":"region",

--- a/data/856/714/65/85671465.geojson
+++ b/data/856/714/65/85671465.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.735819,
-    "geom:area_square_m":8998734709.920876,
+    "geom:area_square_m":8998734709.920866,
     "geom:bbox":"-9.919899,7.754584,-8.856339,9.089725",
     "geom:latitude":8.489765,
     "geom:longitude":-9.326348,
@@ -281,15 +281,17 @@
         "gn:id":2417987,
         "gp:id":-56059376,
         "hasc:id":"GN.MC",
+        "iso:code":"GN-MC",
         "iso:id":"GN-MC",
         "unlc:id":"GN-MC",
         "wd:id":"Q1032064"
     },
+    "wof:concordances_official":"iso:code",
     "wof:coterminous":[
         890455263
     ],
     "wof:country":"GN",
-    "wof:geomhash":"d652551c8669ba03abe7c2b91dc23b8d",
+    "wof:geomhash":"dcd9a244fd3531ce3a6e3c9c0159bf04",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -304,7 +306,7 @@
     "wof:lang_x_spoken":[
         "fra"
     ],
-    "wof:lastmodified":1690921877,
+    "wof:lastmodified":1695884940,
     "wof:name":"Macenta",
     "wof:parent_id":85632691,
     "wof:placetype":"region",

--- a/data/856/714/67/85671467.geojson
+++ b/data/856/714/67/85671467.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.856594,
-    "geom:area_square_m":10358530222.756039,
+    "geom:area_square_m":10358527250.809404,
     "geom:bbox":"-12.862956,11.65294,-11.388422,12.431645",
     "geom:latitude":12.04959,
     "geom:longitude":-12.133498,
@@ -733,11 +733,13 @@
         "gn:id":2417885,
         "gp:id":-56059374,
         "hasc:id":"GN.ML",
+        "iso:code":"GN-ML",
         "iso:id":"GN-ML",
         "unlc:id":"GN-ML"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"GN",
-    "wof:geomhash":"7d6e2338d073da368297d9fa13b0ea06",
+    "wof:geomhash":"f3409137084e463bac5c98395be6c89d",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -752,7 +754,7 @@
     "wof:lang_x_spoken":[
         "fra"
     ],
-    "wof:lastmodified":1636502718,
+    "wof:lastmodified":1695884940,
     "wof:name":"Mali",
     "wof:parent_id":85632691,
     "wof:placetype":"region",

--- a/data/856/714/73/85671473.geojson
+++ b/data/856/714/73/85671473.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.656292,
-    "geom:area_square_m":7979656179.396169,
+    "geom:area_square_m":7979656122.8851,
     "geom:bbox":"-12.426006,9.881676,-11.249235,11.326182",
     "geom:latitude":10.481152,
     "geom:longitude":-11.863166,
@@ -229,11 +229,13 @@
         "gn:id":2417831,
         "gp:id":-56059375,
         "hasc:id":"GN.MM",
+        "iso:code":"GN-MM",
         "iso:id":"GN-MM",
         "wd:id":"Q623295"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"GN",
-    "wof:geomhash":"72099badbc9f4d5b435efeba889da9f8",
+    "wof:geomhash":"b64f27bf9023aa0a361f1343d55b5a1f",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -248,7 +250,7 @@
     "wof:lang_x_spoken":[
         "fra"
     ],
-    "wof:lastmodified":1690921875,
+    "wof:lastmodified":1695884940,
     "wof:name":"Mamou",
     "wof:parent_id":85632691,
     "wof:placetype":"region",

--- a/data/856/714/79/85671479.geojson
+++ b/data/856/714/79/85671479.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.915033,
-    "geom:area_square_m":11116410242.352476,
+    "geom:area_square_m":11116408683.613947,
     "geom:bbox":"-9.373097,9.949988,-7.962584,11.649471",
     "geom:latitude":10.732004,
     "geom:longitude":-8.627584,
@@ -188,12 +188,14 @@
         "gn:id":2595305,
         "gp:id":-56059378,
         "hasc:id":"GN.MD",
+        "iso:code":"GN-MD",
         "iso:id":"GN-MD",
         "unlc:id":"GN-MD",
         "wd:id":"Q6748057"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"GN",
-    "wof:geomhash":"0a781f0ebae508120d7dcb6076479e80",
+    "wof:geomhash":"e58afbb78b01b2b3c3c7d5642d5584af",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -208,7 +210,7 @@
     "wof:lang_x_spoken":[
         "fra"
     ],
-    "wof:lastmodified":1690921879,
+    "wof:lastmodified":1695884940,
     "wof:name":"Mandiana",
     "wof:parent_id":85632691,
     "wof:placetype":"region",

--- a/data/856/714/83/85671483.geojson
+++ b/data/856/714/83/85671483.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.31146,
-    "geom:area_square_m":3813622513.067475,
+    "geom:area_square_m":3813622674.935553,
     "geom:bbox":"-9.069404,7.622017,-8.429713,8.364177",
     "geom:latitude":8.015673,
     "geom:longitude":-8.739435,
@@ -217,11 +217,13 @@
         "gn:id":2416968,
         "gp:id":-56059376,
         "hasc:id":"GN.NZ",
+        "iso:code":"GN-NZ",
         "iso:id":"GN-NZ",
         "wd:id":"Q1471203"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"GN",
-    "wof:geomhash":"ee2b3ed3a44f602fb344ba91cbb45a5c",
+    "wof:geomhash":"e651d117eb3480e9748a5f013e12380d",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -236,7 +238,7 @@
     "wof:lang_x_spoken":[
         "fra"
     ],
-    "wof:lastmodified":1690921880,
+    "wof:lastmodified":1695884326,
     "wof:name":"Nz\u00e9r\u00e9kor\u00e9",
     "wof:parent_id":85632691,
     "wof:placetype":"region",

--- a/data/856/714/85/85671485.geojson
+++ b/data/856/714/85/85671485.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.340794,
-    "geom:area_square_m":4137542958.695389,
+    "geom:area_square_m":4137542958.695446,
     "geom:bbox":"-12.964035,10.469938,-12.121839,11.321661",
     "geom:latitude":10.928098,
     "geom:longitude":-12.623445,
@@ -314,15 +314,17 @@
         "gn:id":2416440,
         "gp:id":-56059375,
         "hasc:id":"GN.PI",
+        "iso:code":"GN-PI",
         "iso:id":"GN-PI",
         "unlc:id":"GN-PI",
         "wd:id":"Q211340"
     },
+    "wof:concordances_official":"iso:code",
     "wof:coterminous":[
         421182471
     ],
     "wof:country":"GN",
-    "wof:geomhash":"f266a01af23f007ce05440e1bd9ec96e",
+    "wof:geomhash":"377f146ff3dd8da46ee819c7890f1042",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -337,7 +339,7 @@
     "wof:lang_x_spoken":[
         "fra"
     ],
-    "wof:lastmodified":1690921880,
+    "wof:lastmodified":1695884940,
     "wof:name":"Pita",
     "wof:parent_id":85632691,
     "wof:placetype":"region",

--- a/data/856/714/89/85671489.geojson
+++ b/data/856/714/89/85671489.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.467732,
-    "geom:area_square_m":17775806615.067043,
+    "geom:area_square_m":17775806615.067005,
     "geom:bbox":"-10.207718,10.863844,-8.726517,12.497533",
     "geom:latitude":11.63024,
     "geom:longitude":-9.405549,
@@ -214,14 +214,16 @@
         "gn:id":2415702,
         "gp:id":-56059378,
         "hasc:id":"GN.SI",
+        "iso:code":"GN-SI",
         "iso:id":"GN-SI",
         "unlc:id":"GN-SI"
     },
+    "wof:concordances_official":"iso:code",
     "wof:coterminous":[
         421198017
     ],
     "wof:country":"GN",
-    "wof:geomhash":"b2fee7bba74d3fd960cd60b44225ed2b",
+    "wof:geomhash":"17d0413630c17558f4f696c18b0b0546",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -236,7 +238,7 @@
     "wof:lang_x_spoken":[
         "fra"
     ],
-    "wof:lastmodified":1636502718,
+    "wof:lastmodified":1695884940,
     "wof:name":"Siguiri",
     "wof:parent_id":85632691,
     "wof:placetype":"region",

--- a/data/856/714/97/85671497.geojson
+++ b/data/856/714/97/85671497.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.370934,
-    "geom:area_square_m":4495486962.453671,
+    "geom:area_square_m":4495488641.414845,
     "geom:bbox":"-12.005489,10.99951,-11.119313,12.040403",
     "geom:latitude":11.440913,
     "geom:longitude":-11.516997,
@@ -185,12 +185,14 @@
         "gn:id":2414544,
         "gp:id":-56059374,
         "hasc:id":"GN.TO",
+        "iso:code":"GN-TO",
         "iso:id":"GN-TO",
         "unlc:id":"GN-TO",
         "wd:id":"Q7828837"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"GN",
-    "wof:geomhash":"0e7db501881f031d4aa6dc2b223ef44d",
+    "wof:geomhash":"972e38577d8b93507c4f5341973fa0eb",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -205,7 +207,7 @@
     "wof:lang_x_spoken":[
         "fra"
     ],
-    "wof:lastmodified":1690921879,
+    "wof:lastmodified":1695884326,
     "wof:name":"Tougu\u00e9",
     "wof:parent_id":85632691,
     "wof:placetype":"region",

--- a/data/856/714/99/85671499.geojson
+++ b/data/856/714/99/85671499.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.333568,
-    "geom:area_square_m":4088537831.423529,
+    "geom:area_square_m":4088539081.399188,
     "geom:bbox":"-9.490708,7.190208,-8.725742,8.053227",
     "geom:latitude":7.583452,
     "geom:longitude":-9.087376,
@@ -241,12 +241,14 @@
         "gn:id":2414077,
         "gp:id":-56059376,
         "hasc:id":"GN.YO",
+        "iso:code":"GN-YO",
         "iso:id":"GN-YO",
         "unlc:id":"GN-YO",
         "wd:id":"Q784157"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"GN",
-    "wof:geomhash":"8b39b2d29a650833afbf4009621dfcb9",
+    "wof:geomhash":"e600c26285e01e609bf0a4a7ffd97aed",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -261,7 +263,7 @@
     "wof:lang_x_spoken":[
         "fra"
     ],
-    "wof:lastmodified":1690921878,
+    "wof:lastmodified":1695884940,
     "wof:name":"Yomou",
     "wof:parent_id":85632691,
     "wof:placetype":"region",

--- a/data/856/715/03/85671503.geojson
+++ b/data/856/715/03/85671503.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.631316,
-    "geom:area_square_m":7664987267.198778,
+    "geom:area_square_m":7664987267.198736,
     "geom:bbox":"-14.144532,10.397239,-12.874868,11.366102",
     "geom:latitude":10.91821,
     "geom:longitude":-13.398595,
@@ -191,15 +191,17 @@
         "gn:id":2414925,
         "gp:id":-56059377,
         "hasc:id":"GN.TE",
+        "iso:code":"GN-TE",
         "iso:id":"GN-TE",
         "unlc:id":"GN-TE",
         "wd:id":"Q7862201"
     },
+    "wof:concordances_official":"iso:code",
     "wof:coterminous":[
         421180037
     ],
     "wof:country":"GN",
-    "wof:geomhash":"323e8fc401bb3193e6361c50aed0e94a",
+    "wof:geomhash":"331dff4d965f3d2f1b6b6c317a9c0822",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -214,7 +216,7 @@
     "wof:lang_x_spoken":[
         "fra"
     ],
-    "wof:lastmodified":1690921882,
+    "wof:lastmodified":1695884473,
     "wof:name":"T\u00e9lim\u00e9l\u00e9",
     "wof:parent_id":85632691,
     "wof:placetype":"region",

--- a/data/890/420/101/890420101.geojson
+++ b/data/890/420/101/890420101.geojson
@@ -151,6 +151,7 @@
         "hasc:id":"GN.DB",
         "qs_pg:id":91437
     },
+    "wof:concordances_official":"hasc:id",
     "wof:coterminous":[
         85671381
     ],
@@ -169,7 +170,7 @@
         }
     ],
     "wof:id":890420101,
-    "wof:lastmodified":1694492941,
+    "wof:lastmodified":1695886071,
     "wof:name":"Dabola",
     "wof:parent_id":85671381,
     "wof:placetype":"county",

--- a/data/890/420/105/890420105.geojson
+++ b/data/890/420/105/890420105.geojson
@@ -151,6 +151,7 @@
         "wd:id":"Q891238",
         "wk:page":"Bok\u00e9 Prefecture"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GN",
     "wof:created":1469051318,
     "wof:geom_alt":[
@@ -166,7 +167,7 @@
         }
     ],
     "wof:id":890420105,
-    "wof:lastmodified":1694492942,
+    "wof:lastmodified":1695886071,
     "wof:name":"Boke",
     "wof:parent_id":85671367,
     "wof:placetype":"county",

--- a/data/890/429/077/890429077.geojson
+++ b/data/890/429/077/890429077.geojson
@@ -144,6 +144,7 @@
         "wd:id":"Q581719",
         "wk:page":"Kankan Prefecture"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GN",
     "wof:created":1469051791,
     "wof:geom_alt":[
@@ -159,7 +160,7 @@
         }
     ],
     "wof:id":890429077,
-    "wof:lastmodified":1694492941,
+    "wof:lastmodified":1695886071,
     "wof:name":"Kankan",
     "wof:parent_id":85671421,
     "wof:placetype":"county",

--- a/data/890/454/187/890454187.geojson
+++ b/data/890/454/187/890454187.geojson
@@ -102,6 +102,7 @@
         "hasc:id":"GN.KB",
         "qs_pg:id":575130
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GN",
     "wof:created":1469052890,
     "wof:geom_alt":[
@@ -117,7 +118,7 @@
         }
     ],
     "wof:id":890454187,
-    "wof:lastmodified":1694492941,
+    "wof:lastmodified":1695886071,
     "wof:name":"Koubia",
     "wof:parent_id":85671467,
     "wof:placetype":"county",

--- a/data/890/454/189/890454189.geojson
+++ b/data/890/454/189/890454189.geojson
@@ -180,6 +180,7 @@
         "wd:id":"Q253661",
         "wk:page":"L\u00e9louma Prefecture"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GN",
     "wof:created":1469052890,
     "wof:geom_alt":[
@@ -195,7 +196,7 @@
         }
     ],
     "wof:id":890454189,
-    "wof:lastmodified":1694492674,
+    "wof:lastmodified":1695886627,
     "wof:name":"Lelouma",
     "wof:parent_id":85671455,
     "wof:placetype":"county",

--- a/data/890/455/259/890455259.geojson
+++ b/data/890/455/259/890455259.geojson
@@ -132,6 +132,7 @@
         "wd:id":"Q1471203",
         "wk:page":"Nz\u00e9r\u00e9kor\u00e9 Prefecture"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GN",
     "wof:created":1469052940,
     "wof:geom_alt":[
@@ -147,7 +148,7 @@
         }
     ],
     "wof:id":890455259,
-    "wof:lastmodified":1694492674,
+    "wof:lastmodified":1695886627,
     "wof:name":"Nzerekore",
     "wof:parent_id":85671483,
     "wof:placetype":"county",

--- a/data/890/455/261/890455261.geojson
+++ b/data/890/455/261/890455261.geojson
@@ -196,6 +196,7 @@
         "wd:id":"Q1781017",
         "wk:page":"Mali Prefecture"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GN",
     "wof:created":1469052940,
     "wof:geom_alt":[
@@ -211,7 +212,7 @@
         }
     ],
     "wof:id":890455261,
-    "wof:lastmodified":1694492941,
+    "wof:lastmodified":1695886071,
     "wof:name":"Mali",
     "wof:parent_id":85671467,
     "wof:placetype":"county",

--- a/data/890/455/263/890455263.geojson
+++ b/data/890/455/263/890455263.geojson
@@ -159,6 +159,7 @@
         "hasc:id":"GN.MC",
         "qs_pg:id":91428
     },
+    "wof:concordances_official":"hasc:id",
     "wof:coterminous":[
         85671465
     ],
@@ -177,7 +178,7 @@
         }
     ],
     "wof:id":890455263,
-    "wof:lastmodified":1694492941,
+    "wof:lastmodified":1695886071,
     "wof:name":"Macenta",
     "wof:parent_id":85671465,
     "wof:placetype":"county",

--- a/data/890/455/267/890455267.geojson
+++ b/data/890/455/267/890455267.geojson
@@ -150,6 +150,7 @@
         "hasc:id":"GN.KI",
         "qs_pg:id":91430
     },
+    "wof:concordances_official":"hasc:id",
     "wof:coterminous":[
         85671429
     ],
@@ -168,7 +169,7 @@
         }
     ],
     "wof:id":890455267,
-    "wof:lastmodified":1694492941,
+    "wof:lastmodified":1695886071,
     "wof:name":"Kindia",
     "wof:parent_id":85671429,
     "wof:placetype":"county",


### PR DESCRIPTION
Will fix a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/2164. Sets wof:concordances_official, wof:concordances_official_alt, and wof:label_*_x_preferred properties, and wof:concordances{*:*} hashes when approprirate.